### PR TITLE
Add edge case function to remove schedule pause from a subscription

### DIFF
--- a/paddle_billing_client/client.py
+++ b/paddle_billing_client/client.py
@@ -416,6 +416,15 @@ class PaddleApiClient(APIClient):
             dict(data),
         )
 
+    def unschedule_pause_from_subscription(
+        self, subscription_id: str
+    ) -> SubscriptionResponse:
+        """Remove a scheduled pause from a subscription"""
+        return self.patch(
+            self.endpoints.update_subscription.format(subscription_id=subscription_id),
+            {"scheduled_change": None},
+        )
+
     def get_transaction_to_update_payment_method(
         self, subscription_id: str
     ) -> TransactionResponse:


### PR DESCRIPTION
## Description

https://developer.paddle.com/build/subscriptions/pause-subscriptions#remove-scheduled-change

Removing a scheduled pause from a subscription requires a  `"scheduled_change": null` in the body, which is not possible from pydantic due to Nones are being excluded

## Related Issue

https://github.com/websideproject/paddle-billing-client/issues/196