### PR TITLE
Add `paddle_create_signature_header` helper function to test your webhook implementation

### DIFF
--- a/paddle_billing_client/helpers.py
+++ b/paddle_billing_client/helpers.py
@@ -29,3 +29,26 @@ def validate_webhook_signature(
 
     # Compare the computed signature with the signature extracted from the Paddle-Signature header.
     return hmac.compare_digest(computed_signature, signature)
+
+
+def paddle_create_signature_header(
+    raw_body: bytes, secret_key: str, timestamp: str = "12345"
+) -> str:
+    """Create a paddle signature header to help test your webhook implementation.
+
+    Example usage:
+        data:str = "{json_data_string}"
+        header = paddle_create_signature_header(data.encode())
+        # client is your test client posting in your webhook route
+        r0 = client.post("/paddle_webhook/", data=data, headers={"Paddle-Signature": header, "Content-Type": "application/json"}
+    """
+    # ts=1671552777;h1=eb4d0dc8853be92b7f063b9f3ba5233eb920a09459b6e6b2c26705b4364db151
+    signed_payload = ":".join([timestamp, raw_body.decode("utf-8")])
+    computed_signature = hmac.new(
+        key=secret_key.encode("utf-8"),
+        msg=signed_payload.encode("utf-8"),
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+    header = f"ts={timestamp};h1={computed_signature}"
+    return header


### PR DESCRIPTION
## Description

A small helper function to test your webhook endpoint.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
