### PR TITLE
CustomerBase to allow int values in custom_data

### DIFF
--- a/paddle_billing_client/models/customer.py
+++ b/paddle_billing_client/models/customer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 
 from datetime import datetime
 
@@ -15,7 +15,7 @@ class CustomerBase(BaseModel):
     email: str
     name: str | None = None
     locale: str | None = None
-    custom_data: dict[str, str] | None = None
+    custom_data: dict[str, Union[int, str]] | None = None
 
 
 class Customer(CustomerBase):


### PR DESCRIPTION
added int as type @ CustomerBase custom_data

## Description

Allowing int values in customer data dict eg. ( 'custom_data': { 'account_id': 123 } ) as it is commonly used. Currently updating a customer with int value type results in a pydantic validation error.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/websideproject/paddle-billing-client/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
