### PR TITLE
Make starts_at optional in SubscriptionDiscount

### DIFF
--- a/paddle_billing_client/models/subscription.py
+++ b/paddle_billing_client/models/subscription.py
@@ -37,7 +37,7 @@ class ScheduledChange(BaseModel):
 
 class SubscriptionDiscount(BaseModel):
     id: str
-    starts_at: datetime
+    starts_at: datetime | None = None
     ends_at: datetime | None = None
 
 


### PR DESCRIPTION
## Description

Change model to align with paddle specification

## Related Issue

https://github.com/websideproject/paddle-billing-client/issues/363