### PR TITLE
Make times_used optional due to Paddle bug

### DIFF
--- a/paddle_billing_client/models/discount.py
+++ b/paddle_billing_client/models/discount.py
@@ -29,7 +29,7 @@ class DiscountBase(BaseModel):
 
 class Discount(DiscountBase):
     id: str
-    times_used: int
+    times_used: int | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
     external_id: str | None = None


### PR DESCRIPTION
## Description

Make times_used optional in Discount 

## Related Issue

https://github.com/websideproject/paddle-billing-client/issues/410
